### PR TITLE
ability to ignore fields on update

### DIFF
--- a/src/scala/co/actioniq/luna/dao/DAO.scala
+++ b/src/scala/co/actioniq/luna/dao/DAO.scala
@@ -415,7 +415,7 @@ trait MySQLDAO[T <: MySQLDAOTable[V, I], V <: IdModel[I], I <: IdType] extends D
 trait PostgresDAO[T <: PostgresDAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, PostgresProfile]
   with JdbcTypeImplicits.postgresJdbcTypeImplicits.DbImplicits
 
-trait H2DAO[T <: H2DAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, H2Profile]
+trait H2DAO[T <: H2DAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, CoolH2Profile]
   with JdbcTypeImplicits.h2JdbcTypeImplicits.DbImplicits{
-  override protected val profile = H2Profile
+  override protected val profile = CoolH2Profile
 }

--- a/src/scala/co/actioniq/luna/dao/DAO.scala
+++ b/src/scala/co/actioniq/luna/dao/DAO.scala
@@ -409,13 +409,13 @@ trait DAO[T <: DAOTable.Table[V, I, P], V <: IdModel[I], I <: IdType, P <: JdbcP
   }
 }
 
-trait MySQLDAO[T <: MySQLDAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, MySQLProfile]
+trait MySQLDAO[T <: MySQLDAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, DAOMySQLProfile]
   with JdbcTypeImplicits.mySQLJdbcTypeImplicits.DbImplicits
 
 trait PostgresDAO[T <: PostgresDAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, PostgresProfile]
   with JdbcTypeImplicits.postgresJdbcTypeImplicits.DbImplicits
 
-trait H2DAO[T <: H2DAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, CoolH2Profile]
+trait H2DAO[T <: H2DAOTable[V, I], V <: IdModel[I], I <: IdType] extends DAO[T, V, I, DAOH2Profile]
   with JdbcTypeImplicits.h2JdbcTypeImplicits.DbImplicits{
-  override protected val profile = CoolH2Profile
+  override protected val profile = DAOH2Profile
 }

--- a/src/scala/co/actioniq/luna/dao/DAOH2Profile.scala
+++ b/src/scala/co/actioniq/luna/dao/DAOH2Profile.scala
@@ -1,0 +1,11 @@
+package co.actioniq.luna.dao
+
+import slick.compiler.Phase
+import slick.driver.JdbcProfile
+import slick.jdbc.H2Profile
+
+trait DAOH2Profile extends H2Profile { self => JdbcProfile
+  override lazy val updateCompiler = (compiler + new JdbcCodeGen(_.buildUpdate)).addAfter(new IgnoreUpdateCompiler(), Phase.hoistClientOps)
+}
+
+object DAOH2Profile extends DAOH2Profile

--- a/src/scala/co/actioniq/luna/dao/DAOMySQLProfile.scala
+++ b/src/scala/co/actioniq/luna/dao/DAOMySQLProfile.scala
@@ -9,12 +9,14 @@ trait DAOMySQLProfile extends MySQLProfile {
 
 object DAOMySQLProfile extends DAOMySQLProfile {
   import slick.ast._
+  //Copied from MySQLProfile
   final case class RowNum(sym: AnonSymbol, inc: Boolean) extends NullaryNode with SimplyTypedNode {
     type Self = RowNum
     def buildType = ScalaBaseType.longType
     def rebuild = copy()
   }
 
+  //Copied from MySQLProfile
   final case class RowNumGen(sym: AnonSymbol, init: Long) extends NullaryNode with SimplyTypedNode {
     type Self = RowNumGen
     def buildType = ScalaBaseType.longType

--- a/src/scala/co/actioniq/luna/dao/DAOMySQLProfile.scala
+++ b/src/scala/co/actioniq/luna/dao/DAOMySQLProfile.scala
@@ -1,0 +1,23 @@
+package co.actioniq.luna.dao
+
+import slick.compiler.Phase
+import slick.jdbc.MySQLProfile
+
+trait DAOMySQLProfile extends MySQLProfile {
+  override lazy val updateCompiler = (compiler + new JdbcCodeGen(_.buildUpdate)).addAfter(new IgnoreUpdateCompiler(), Phase.hoistClientOps)
+}
+
+object DAOMySQLProfile extends DAOMySQLProfile {
+  import slick.ast._
+  final case class RowNum(sym: AnonSymbol, inc: Boolean) extends NullaryNode with SimplyTypedNode {
+    type Self = RowNum
+    def buildType = ScalaBaseType.longType
+    def rebuild = copy()
+  }
+
+  final case class RowNumGen(sym: AnonSymbol, init: Long) extends NullaryNode with SimplyTypedNode {
+    type Self = RowNumGen
+    def buildType = ScalaBaseType.longType
+    def rebuild = copy()
+  }
+}

--- a/src/scala/co/actioniq/luna/dao/DAOTable.scala
+++ b/src/scala/co/actioniq/luna/dao/DAOTable.scala
@@ -22,11 +22,13 @@ abstract class MySQLDAOTable[V <: IdModel[I], I <: IdType](
   tag: Tag,
   tableName: String,
   schemaName: Option[String] = None
-) extends MySQLProfile.Table[V](tag, schemaName, tableName)
+) extends CoolMySQLProfile.Table[V](tag, schemaName, tableName)
   with IdTable[I]
   with JdbcTypeImplicits.mySQLJdbcTypeImplicits.DbImplicits {
-  self: DAOTable.Table[V, I, MySQLProfile] =>
+  self: DAOTable.Table[V, I, CoolMySQLProfile] =>
 }
+
+
 
 abstract class PostgresDAOTable[V <: IdModel[I], I <: IdType](
   tag: Tag,
@@ -42,10 +44,10 @@ abstract class H2DAOTable[V <: IdModel[I], I <: IdType](
   tag: Tag,
   tableName: String,
   schemaName: Option[String] = None
-) extends H2Profile.Table[V](tag, schemaName, tableName)
+) extends CoolH2Profile.Table[V](tag, schemaName, tableName)
   with IdTable[I]
   with JdbcTypeImplicits.h2JdbcTypeImplicits.DbImplicits {
-  self: DAOTable.Table[V, I, H2Profile] =>
+  self: DAOTable.Table[V, I, CoolH2Profile] =>
 }
 
 class DAODynamicProfileTable[P <: JdbcProfile] (
@@ -59,4 +61,98 @@ class DAODynamicProfileTable[P <: JdbcProfile] (
   ) extends profile.Table[V](tag, schemaName, tableName)
     with IdTable[I]
     with implicits.DbImplicits
+}
+
+trait CoolMySQLProfile extends MySQLProfile {
+  import slick.ast._
+  import slick.util.ConstArray
+  import slick.SlickException
+  import slick.compiler.CompilerState
+  import slick.util.MacroSupport.macroSupportInterpolation
+  class OtherQueryBuilder(override val tree: Node, override val state: CompilerState) extends QueryBuilder(tree, state) {
+    override def buildUpdate = {
+      val (gen, from, where, select) = tree match {
+        case Comprehension(sym, from: TableNode, Pure(select, _), where, None, _, None, None, None, None, false) => select match {
+          case f @ Select(Ref(struct), _) if struct == sym => (sym, from, where, ConstArray(f.field))
+          case ProductNode(ch) if ch.forall{ case Select(Ref(struct), _) if struct == sym => true; case _ => false} =>
+            (sym, from, where, ch.map{ case Select(Ref(_), field) => field })
+          case _ => throw new SlickException("A query for an UPDATE statement must select table columns only -- Unsupported shape: "+select)
+        }
+        case o => throw new SlickException("A query for an UPDATE statement must resolve to a comprehension with a single table -- Unsupported shape: "+o)
+      }
+
+      val qtn = quoteTableName(from)
+      symbolName(gen) = qtn // Alias table to itself because UPDATE does not support aliases
+      b"update $qtn set "
+      b.sep(select, ", ")(field => b += symbolName(field) += " = ?")
+      if(!where.isEmpty) {
+        b" where "
+        expr(where.reduceLeft((a, b) => Library.And.typed[Boolean](a, b)), true)
+      }
+      b.build
+    }
+  }
+  override def createQueryBuilder(n: slick.ast.Node, state: slick.compiler.CompilerState): QueryBuilder = new OtherQueryBuilder(n, state)
+  override lazy val updateCompiler = compiler + new JdbcCodeGen(_.buildUpdate)
+}
+
+object CoolMySQLProfile extends CoolMySQLProfile {
+  import slick.ast._
+  final case class RowNum(sym: AnonSymbol, inc: Boolean) extends NullaryNode with SimplyTypedNode {
+    type Self = RowNum
+    def buildType = ScalaBaseType.longType
+    def rebuild = copy()
+  }
+
+  final case class RowNumGen(sym: AnonSymbol, init: Long) extends NullaryNode with SimplyTypedNode {
+    type Self = RowNumGen
+    def buildType = ScalaBaseType.longType
+    def rebuild = copy()
+  }
+}
+
+trait CoolH2Profile extends H2Profile {
+  import slick.ast._
+  import slick.util.ConstArray
+  import slick.SlickException
+  import slick.compiler.CompilerState
+  import slick.util.MacroSupport.macroSupportInterpolation
+  class OtherQueryBuilder(override val tree: Node, override val state: CompilerState) extends QueryBuilder(tree, state) {
+    override def buildUpdate = {
+      val (gen, from, where, select) = tree match {
+        case Comprehension(sym, from: TableNode, Pure(select, _), where, None, _, None, None, None, None, false) => select match {
+          case f @ Select(Ref(struct), _) if struct == sym => (sym, from, where, ConstArray(f.field))
+          case ProductNode(ch) if ch.forall{ case Select(Ref(struct), _) if struct == sym => true; case _ => false} =>
+            (sym, from, where, ch.map{ case Select(Ref(_), field) => field })
+          case _ => throw new SlickException("A query for an UPDATE statement must select table columns only -- Unsupported shape: "+select)
+        }
+        case o => throw new SlickException("A query for an UPDATE statement must resolve to a comprehension with a single table -- Unsupported shape: "+o)
+      }
+
+      println(s"boom boom")
+      val selectsForUpdate = select.filter {
+        case s: FieldSymbol => !s.options.contains(CoolColumnOption.IgnoreUpdate)
+        case _ => true
+      }
+      val qtn = quoteTableName(from)
+      symbolName(gen) = qtn // Alias table to itself because UPDATE does not support aliases
+      b"update $qtn set "
+      b.sep(selectsForUpdate, ", ")(field => b += symbolName(field) += " = ?")
+      if(!where.isEmpty) {
+        b" where "
+        expr(where.reduceLeft((a, b) => Library.And.typed[Boolean](a, b)), true)
+      }
+      b.build
+    }
+  }
+  override def createQueryBuilder(n: slick.ast.Node, state: slick.compiler.CompilerState): QueryBuilder = new OtherQueryBuilder(n, state)
+  override lazy val updateCompiler = compiler + new JdbcCodeGen(_.buildUpdate)
+
+}
+
+object CoolH2Profile extends CoolH2Profile
+
+object CoolColumnOption {
+  import slick.ast.ColumnOption
+  case object IgnoreUpdate extends ColumnOption[Nothing]
 }

--- a/src/scala/co/actioniq/luna/dao/DAOTable.scala
+++ b/src/scala/co/actioniq/luna/dao/DAOTable.scala
@@ -191,33 +191,16 @@ class IgnoreUpdateCompiler extends Phase {
   }
 
   def tupleToFilteredTuple(input: Product, fieldsToRemove: Map[Int, Boolean]): Product = {
-    input.productIterator.zipWithIndex.filter{ row =>
-      !fieldsToRemove(row._2)
-    }.map(_._1).toList match {
-      case List(a) => Tuple1(a)
-      case List(a, b) => (a, b)
-      case List(a, b, c) => (a, b, c)
-      case List(a, b, c, d) => (a, b, c, d)
-      case List(a, b, c, d, e) => (a, b, c, d, e)
-      case List(a, b, c, d, e, f) => (a, b, c, d, e, f)
-      case List(a, b, c, d, e, f, g) => (a, b, c, d, e, f, g)
-      case List(a, b, c, d, e, f, g, h) => (a, b, c, d, e, f, g, h)
-      case List(a, b, c, d, e, f, g, h, i) => (a, b, c, d, e, f, g, h, i)
-      case List(a, b, c, d, e, f, g, h, i, j) => (a, b, c, d, e, f, g, h, i, j)
-      case List(a, b, c, d, e, f, g, h, i, j, k) => (a, b, c, d, e, f, g, h, i, j, k)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l) => (a, b, c, d, e, f, g, h, i, j, k, l)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m) => (a, b, c, d, e, f, g, h, i, j, k, l, m)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)
-      case List(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)
+    new Product {
+      private val items = input.productIterator.zipWithIndex.filter{ row =>
+        !fieldsToRemove(row._2)
+      }.map(_._1).toList
+      override def productElement(n: Int): Any = items(n)
+
+      override def productArity: Int = items.size
+
+      override def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
     }
-    //v is 22
   }
 
   def filterImportantFields(elements: ConstArray[(TermSymbol, Node)]): ConstArray[(TermSymbol, Node)] = {

--- a/src/scala/co/actioniq/luna/dao/DAOTable.scala
+++ b/src/scala/co/actioniq/luna/dao/DAOTable.scala
@@ -1,12 +1,8 @@
 package co.actioniq.luna.dao
 
 
-import slick.compiler.InsertCompiler.Mode
-import slick.compiler.{CompilerState, Phase}
-import slick.driver.JdbcProfile
-import slick.jdbc.{H2Profile, JdbcProfile, MySQLProfile, PostgresProfile}
+import slick.jdbc.{JdbcProfile, PostgresProfile}
 import slick.lifted.Tag
-import slick.util.ConstArray
 
 
 /**
@@ -26,10 +22,10 @@ abstract class MySQLDAOTable[V <: IdModel[I], I <: IdType](
   tag: Tag,
   tableName: String,
   schemaName: Option[String] = None
-) extends CoolMySQLProfile.Table[V](tag, schemaName, tableName)
+) extends DAOMySQLProfile.Table[V](tag, schemaName, tableName)
   with IdTable[I]
   with JdbcTypeImplicits.mySQLJdbcTypeImplicits.DbImplicits {
-  self: DAOTable.Table[V, I, CoolMySQLProfile] =>
+  self: DAOTable.Table[V, I, DAOMySQLProfile] =>
 }
 
 
@@ -48,10 +44,10 @@ abstract class H2DAOTable[V <: IdModel[I], I <: IdType](
   tag: Tag,
   tableName: String,
   schemaName: Option[String] = None
-) extends CoolH2Profile.Table[V](tag, schemaName, tableName)
+) extends DAOH2Profile.Table[V](tag, schemaName, tableName)
   with IdTable[I]
   with JdbcTypeImplicits.h2JdbcTypeImplicits.DbImplicits {
-  self: DAOTable.Table[V, I, CoolH2Profile] =>
+  self: DAOTable.Table[V, I, DAOH2Profile] =>
 }
 
 class DAODynamicProfileTable[P <: JdbcProfile] (
@@ -65,154 +61,4 @@ class DAODynamicProfileTable[P <: JdbcProfile] (
   ) extends profile.Table[V](tag, schemaName, tableName)
     with IdTable[I]
     with implicits.DbImplicits
-}
-
-trait CoolMySQLProfile extends MySQLProfile {
-  import slick.SlickException
-  import slick.ast._
-  import slick.compiler.CompilerState
-  import slick.util.ConstArray
-  import slick.util.MacroSupport.macroSupportInterpolation
-  class OtherQueryBuilder(override val tree: Node, override val state: CompilerState) extends QueryBuilder(tree, state) {
-    override def buildUpdate = {
-      val (gen, from, where, select) = tree match {
-        case Comprehension(sym, from: TableNode, Pure(select, _), where, None, _, None, None, None, None, false) => select match {
-          case f @ Select(Ref(struct), _) if struct == sym => (sym, from, where, ConstArray(f.field))
-          case ProductNode(ch) if ch.forall{ case Select(Ref(struct), _) if struct == sym => true; case _ => false} =>
-            (sym, from, where, ch.map{ case Select(Ref(_), field) => field })
-          case _ => throw new SlickException("A query for an UPDATE statement must select table columns only -- Unsupported shape: "+select)
-        }
-        case o => throw new SlickException("A query for an UPDATE statement must resolve to a comprehension with a single table -- Unsupported shape: "+o)
-      }
-
-      val qtn = quoteTableName(from)
-      symbolName(gen) = qtn // Alias table to itself because UPDATE does not support aliases
-      b"update $qtn set "
-      b.sep(select, ", ")(field => b += symbolName(field) += " = ?")
-      if(!where.isEmpty) {
-        b" where "
-        expr(where.reduceLeft((a, b) => Library.And.typed[Boolean](a, b)), true)
-      }
-      b.build
-    }
-  }
-
-  override def createQueryBuilder(n: slick.ast.Node, state: slick.compiler.CompilerState): QueryBuilder = new OtherQueryBuilder(n, state)
-  override lazy val updateCompiler = compiler + new JdbcCodeGen(_.buildUpdate)
-}
-
-object CoolMySQLProfile extends CoolMySQLProfile {
-  import slick.ast._
-  final case class RowNum(sym: AnonSymbol, inc: Boolean) extends NullaryNode with SimplyTypedNode {
-    type Self = RowNum
-    def buildType = ScalaBaseType.longType
-    def rebuild = copy()
-  }
-
-  final case class RowNumGen(sym: AnonSymbol, init: Long) extends NullaryNode with SimplyTypedNode {
-    type Self = RowNumGen
-    def buildType = ScalaBaseType.longType
-    def rebuild = copy()
-  }
-}
-
-trait CoolH2Profile extends H2Profile { self => JdbcProfile
-  override lazy val updateCompiler = (compiler + new JdbcCodeGen(_.buildUpdate)).addAfter(new IgnoreUpdateCompiler(), Phase.hoistClientOps)
-}
-
-object CoolH2Profile extends CoolH2Profile
-
-object CoolColumnOption {
-  import slick.ast.ColumnOption
-  case object IgnoreUpdate extends ColumnOption[Nothing]
-}
-
-case object IgnoreFieldForUpdate extends Mode {
-  import slick.ast._
-  def apply(fs: FieldSymbol) = !fs.options.contains(CoolColumnOption.IgnoreUpdate)
-}
-
-
-class IgnoreUpdateCompiler extends Phase {
-  import slick.ast._
-  override val name: String = "ignoreUpdateCompiler"
-
-  override def apply(state: CompilerState): CompilerState = {
-    var fields: ConstArray[FieldSymbol] = ConstArray.empty
-    var fieldsToRemove: Map[Int, Boolean] = Map()
-    state.map {
-      case rsm @ ResultSetMapping(_, from, map) =>
-        val newFrom = from match {
-          case b @ Bind(sym, _, bindSelect) =>
-            val newSelect = bindSelect match {
-              case p @ Pure(pureSelect, _) =>
-                val filteredSelect = pureSelect match {
-                  case struct @ StructNode(elements) if elements.forall{ case (_, Select(Ref(str), _)) if str == sym => true; case _ => false} =>
-                    fields = elements.map {
-                      case (_, s @ Select(Ref(_), fieldInfo: FieldSymbol)) => fieldInfo
-                    }
-                    fieldsToRemove = getFieldsToRemove(fields)
-                    struct.copy(elements=filterImportantFields(elements))
-                  case n => n
-                }
-                p.copy(value=filteredSelect)
-              case n => n
-            }
-            b.copy(select = newSelect).infer()
-          case n => n
-        }
-        val newMap = map match {
-          case typey @ TypeMapping(child, mapper, classTag) =>
-            val newChild = child match {
-              case pn @ ProductNode(children) =>
-                val newChildren = children.toSeq.zipWithIndex.filter { row =>
-                  !fieldsToRemove(row._2)
-                }.map(_._1).zipWithIndex.map(_._1)
-                pn.copy(children=ConstArray.from(newChildren))
-              case n => n
-            }
-            val newMapper = mapper.copy(toBase = a => {
-              val result = mapper.toBase(a)
-              result match {
-                case x: Product =>
-                  tupleToFilteredTuple(x, fieldsToRemove)
-                case n => n
-              }
-            })
-            typey.copy(mapper = newMapper, child=newChild)
-          case n => n
-        }
-        map match {
-          case TypeMapping(_, _, _) => rsm.copy(from = newFrom, map = newMap)
-          case n => rsm
-        }
-      case n => n
-    }
-  }
-
-  def tupleToFilteredTuple(input: Product, fieldsToRemove: Map[Int, Boolean]): Product = {
-    new Product {
-      private val items = input.productIterator.zipWithIndex.filter{ row =>
-        !fieldsToRemove(row._2)
-      }.map(_._1).toList
-      override def productElement(n: Int): Any = items(n)
-
-      override def productArity: Int = items.size
-
-      override def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
-    }
-  }
-
-  def filterImportantFields(elements: ConstArray[(TermSymbol, Node)]): ConstArray[(TermSymbol, Node)] = {
-    elements.filter {
-      case (_, s @ Select(Ref(_), fieldInfo: FieldSymbol)) => !fieldInfo.options.contains(CoolColumnOption.IgnoreUpdate)
-    }
-  }
-
-  def getFieldsToRemove(fields: ConstArray[FieldSymbol]): Map[Int, Boolean] = {
-    fields.zipWithIndex.map { rowWithIndex =>
-      val isImportant = rowWithIndex._1.options.contains(CoolColumnOption.IgnoreUpdate)
-      (rowWithIndex._2, isImportant)
-    }.toMap
-  }
 }

--- a/src/scala/co/actioniq/luna/dao/IgnoreUpdateCompiler.scala
+++ b/src/scala/co/actioniq/luna/dao/IgnoreUpdateCompiler.scala
@@ -1,0 +1,112 @@
+package co.actioniq.luna.dao
+
+import slick.compiler.InsertCompiler.Mode
+import slick.compiler.{CompilerState, Phase}
+import slick.util.ConstArray
+
+/**
+  * The goal of this compile stage is to remove fields from update statements that should not be updated when using
+  * case classes.  This is useful for updating using a case class and ignoring indexed fields, which would cause a
+  * deadlock.  This only removes fields from updating using a case class, sqlu and updating specific fields
+  * are not affected by this compiler.
+  *
+  * How it works:
+  * 1. Assumes ResultSetMapping state (probably after hoistClientOps).
+  * 2. Looks for fields in "from" with column option of IgnoreFieldForUpdate.  Removes those.
+  * 3. Removes from mapper fields with same ordinal position as fields in #2.
+  * 4. Creates a new "wrapper" function around mapper (mapper function goes from case class to tuple)
+  * that will create a tuple without ignored fields.
+  */
+class IgnoreUpdateCompiler extends Phase {
+  import slick.ast._
+  override val name: String = "ignoreUpdateCompiler"
+
+  override def apply(state: CompilerState): CompilerState = {
+    var fields: ConstArray[FieldSymbol] = ConstArray.empty
+    var fieldsToRemove: Map[Int, Boolean] = Map()
+    state.map {
+      case rsm @ ResultSetMapping(_, from, map) =>
+        val newFrom = from match {
+          case b @ Bind(sym, _, bindSelect) =>
+            val newSelect = bindSelect match {
+              case p @ Pure(pureSelect, _) =>
+                val filteredSelect = pureSelect match {
+                  case struct @ StructNode(elements) if elements.forall{ case (_, Select(Ref(str), _)) if str == sym => true; case _ => false} =>
+                    fields = elements.map {
+                      case (_, s @ Select(Ref(_), fieldInfo: FieldSymbol)) => fieldInfo
+                    }
+                    fieldsToRemove = getFieldsToRemove(fields)
+                    struct.copy(elements=filterImportantFields(elements))
+                  case n => n
+                }
+                p.copy(value=filteredSelect)
+              case n => n
+            }
+            b.copy(select = newSelect).infer()
+          case n => n
+        }
+        val newMap = map match {
+          case typey @ TypeMapping(child, mapper, _) =>
+            val newChild = child match {
+              case pn @ ProductNode(children) =>
+                val newChildren = children.toSeq.zipWithIndex.filter { row =>
+                  !fieldsToRemove(row._2)
+                }.map(_._1).zipWithIndex.map(_._1)
+                pn.copy(children=ConstArray.from(newChildren))
+              case n => n
+            }
+            val newMapper = mapper.copy(toBase = a => {
+              val result = mapper.toBase(a)
+              result match {
+                case x: Product =>
+                  tupleToFilteredTuple(x, fieldsToRemove)
+                case n => n
+              }
+            })
+            typey.copy(mapper = newMapper, child=newChild)
+          case n => n
+        }
+        map match {
+          case TypeMapping(_, _, _) => rsm.copy(from = newFrom, map = newMap)
+          case n => rsm
+        }
+      case n => n
+    }
+  }
+
+  def tupleToFilteredTuple(input: Product, fieldsToRemove: Map[Int, Boolean]): Product = {
+    new Product {
+      private val items = input.productIterator.zipWithIndex.filter{ row =>
+        !fieldsToRemove(row._2)
+      }.map(_._1).toList
+      override def productElement(n: Int): Any = items(n)
+
+      override def productArity: Int = items.size
+
+      override def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+    }
+  }
+
+  def filterImportantFields(elements: ConstArray[(TermSymbol, Node)]): ConstArray[(TermSymbol, Node)] = {
+    elements.filter {
+      case (_, Select(Ref(_), fieldInfo: FieldSymbol)) => !fieldInfo.options.contains(ExtraColumnOption.IgnoreUpdate)
+    }
+  }
+
+  def getFieldsToRemove(fields: ConstArray[FieldSymbol]): Map[Int, Boolean] = {
+    fields.zipWithIndex.map { rowWithIndex =>
+      val isImportant = rowWithIndex._1.options.contains(ExtraColumnOption.IgnoreUpdate)
+      (rowWithIndex._2, isImportant)
+    }.toMap
+  }
+}
+
+object ExtraColumnOption {
+  import slick.ast.ColumnOption
+  case object IgnoreUpdate extends ColumnOption[Nothing]
+}
+
+case object IgnoreFieldForUpdate extends Mode {
+  import slick.ast._
+  def apply(fs: FieldSymbol) = !fs.options.contains(ExtraColumnOption.IgnoreUpdate)
+}

--- a/src/scala/co/actioniq/luna/dao/IgnoreUpdateCompiler.scala
+++ b/src/scala/co/actioniq/luna/dao/IgnoreUpdateCompiler.scala
@@ -22,7 +22,6 @@ class IgnoreUpdateCompiler extends Phase {
   override val name: String = "ignoreUpdateCompiler"
 
   override def apply(state: CompilerState): CompilerState = {
-    var fields: ConstArray[FieldSymbol] = ConstArray.empty
     var fieldsToRemove: Map[Int, Boolean] = Map()
     state.map {
       case rsm @ ResultSetMapping(_, from, map) =>
@@ -32,7 +31,7 @@ class IgnoreUpdateCompiler extends Phase {
               case p @ Pure(pureSelect, _) =>
                 val filteredSelect = pureSelect match {
                   case struct @ StructNode(elements) if elements.forall{ case (_, Select(Ref(str), _)) if str == sym => true; case _ => false} =>
-                    fields = elements.map {
+                    val fields = elements.map {
                       case (_, s @ Select(Ref(_), fieldInfo: FieldSymbol)) => fieldInfo
                     }
                     fieldsToRemove = getFieldsToRemove(fields)

--- a/src/scala/co/actioniq/luna/dao/JdbcTypeImplicits.scala
+++ b/src/scala/co/actioniq/luna/dao/JdbcTypeImplicits.scala
@@ -42,7 +42,7 @@ class JdbcTypeImplicits[P <: JdbcProfile](val profile: P) {
 }
 
 object JdbcTypeImplicits {
-  val h2JdbcTypeImplicits = new JdbcTypeImplicits[CoolH2Profile](CoolH2Profile)
+  val h2JdbcTypeImplicits = new JdbcTypeImplicits[DAOH2Profile](DAOH2Profile)
   val mySQLJdbcTypeImplicits = new JdbcTypeImplicits[MySQLProfile](MySQLProfile)
   val postgresJdbcTypeImplicits = new JdbcTypeImplicits[PostgresProfile](PostgresProfile)
 }

--- a/src/scala/co/actioniq/luna/dao/JdbcTypeImplicits.scala
+++ b/src/scala/co/actioniq/luna/dao/JdbcTypeImplicits.scala
@@ -42,7 +42,7 @@ class JdbcTypeImplicits[P <: JdbcProfile](val profile: P) {
 }
 
 object JdbcTypeImplicits {
-  val h2JdbcTypeImplicits = new JdbcTypeImplicits[H2Profile](H2Profile)
+  val h2JdbcTypeImplicits = new JdbcTypeImplicits[CoolH2Profile](CoolH2Profile)
   val mySQLJdbcTypeImplicits = new JdbcTypeImplicits[MySQLProfile](MySQLProfile)
   val postgresJdbcTypeImplicits = new JdbcTypeImplicits[PostgresProfile](PostgresProfile)
 }

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -10,5 +10,6 @@
     <root level="OFF">
         <appender-ref ref="console"/>
     </root>
+    <logger name="slick" level="DEBUG"/>
     <!-- logger name="slick.jdbc.JdbcBackend" level="DEBUG" / -->
 </configuration>

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -10,6 +10,5 @@
     <root level="OFF">
         <appender-ref ref="console"/>
     </root>
-    <logger name="slick" level="DEBUG"/>
     <!-- logger name="slick.jdbc.JdbcBackend" level="DEBUG" / -->
 </configuration>

--- a/test/scala/co/actioniq/luna/AiqSlickProfileSpec.scala
+++ b/test/scala/co/actioniq/luna/AiqSlickProfileSpec.scala
@@ -1,9 +1,9 @@
 package co.actioniq.luna
 
 import co.actioniq.luna.OptionCompareOption.optionCompare
-import co.actioniq.luna.dao.{CoolH2Profile, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits, JdbcTypes}
+import co.actioniq.luna.dao.{DAOH2Profile, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits, JdbcTypes}
 import co.actioniq.luna.logging.{NoopBackend, TransactionLogger}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import org.junit.runner.RunWith
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -76,7 +76,7 @@ class AiqSlickProfileSpec extends Specification with Mockito {
     override val slickQuery: TableQuery[PersistedSlickTable]
   ) extends H2DAO[PersistedSlickTable, PersistedSlick, DbLongOptId]
     with NoopBackend
-    with DAOLongIdQuery[PersistedSlickTable, PersistedSlick, CoolH2Profile] {
+    with DAOLongIdQuery[PersistedSlickTable, PersistedSlick, DAOH2Profile] {
 
     def readByIdIfDefined(id: Option[Long]): String = {
       slickQuery.filter(s => optionCompare(s.someId) =:= id).result.statements.toList.head

--- a/test/scala/co/actioniq/luna/AiqSlickProfileSpec.scala
+++ b/test/scala/co/actioniq/luna/AiqSlickProfileSpec.scala
@@ -1,15 +1,15 @@
 package co.actioniq.luna
 
 import co.actioniq.luna.OptionCompareOption.optionCompare
-import co.actioniq.luna.dao.{DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits, JdbcTypes}
+import co.actioniq.luna.dao.{CoolH2Profile, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits, JdbcTypes}
 import co.actioniq.luna.logging.{NoopBackend, TransactionLogger}
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import org.junit.runner.RunWith
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import slick.jdbc.{H2Profile, JdbcProfile}
 import slick.lifted.{TableQuery, Tag}
-import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext
 
@@ -76,7 +76,7 @@ class AiqSlickProfileSpec extends Specification with Mockito {
     override val slickQuery: TableQuery[PersistedSlickTable]
   ) extends H2DAO[PersistedSlickTable, PersistedSlick, DbLongOptId]
     with NoopBackend
-    with DAOLongIdQuery[PersistedSlickTable, PersistedSlick, H2Profile] {
+    with DAOLongIdQuery[PersistedSlickTable, PersistedSlick, CoolH2Profile] {
 
     def readByIdIfDefined(id: Option[Long]): String = {
       slickQuery.filter(s => optionCompare(s.someId) =:= id).result.statements.toList.head

--- a/test/scala/co/actioniq/luna/CompiledQuerySpec.scala
+++ b/test/scala/co/actioniq/luna/CompiledQuerySpec.scala
@@ -4,8 +4,8 @@ import java.util.concurrent.TimeUnit
 
 import co.actioniq.luna.{DBWithLogging, SlickScope}
 import co.actioniq.luna.compiled.{BoundedSeq, BoundedSeq100, InSeqDbUUIDImplicits, SlickCompiledFunctionSingleton}
-import co.actioniq.luna.dao.{CoolH2Profile, DAOUUIDQuery, DbUUID, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.{DAOH2Profile, DAOUUIDQuery, DbUUID, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits}
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import co.actioniq.luna.logging.NoopBackend
 import org.junit.runner.RunWith
 import org.specs2.mock.Mockito
@@ -176,7 +176,7 @@ class PersistedDao(
   override protected val db: DBWithLogging,
   private val persistedSlick: TableQuery[PersistedSlickTable]
 ) extends H2DAO[PersistedSlickTable, PersistedSlick, DbUUID]
-  with DAOUUIDQuery[PersistedSlickTable, PersistedSlick, CoolH2Profile]
+  with DAOUUIDQuery[PersistedSlickTable, PersistedSlick, DAOH2Profile]
   with NoopBackend
   with InSeqDbUUIDImplicits {
   override def validateCreate(

--- a/test/scala/co/actioniq/luna/CompiledQuerySpec.scala
+++ b/test/scala/co/actioniq/luna/CompiledQuerySpec.scala
@@ -4,7 +4,8 @@ import java.util.concurrent.TimeUnit
 
 import co.actioniq.luna.{DBWithLogging, SlickScope}
 import co.actioniq.luna.compiled.{BoundedSeq, BoundedSeq100, InSeqDbUUIDImplicits, SlickCompiledFunctionSingleton}
-import co.actioniq.luna.dao.{DAOUUIDQuery, DbUUID, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits}
+import co.actioniq.luna.dao.{CoolH2Profile, DAOUUIDQuery, DbUUID, FormValidatorMessageSeq, H2DAO, H2DAOTable, IdModel, JdbcTypeImplicits}
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import co.actioniq.luna.logging.NoopBackend
 import org.junit.runner.RunWith
 import org.specs2.mock.Mockito
@@ -12,7 +13,6 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import slick.jdbc.{H2Profile, JdbcProfile}
 import slick.lifted.{AppliedCompiledFunction, CompiledFunction, CompiledStreamingExecutable, TableQuery, Tag}
-import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.{Duration, SECONDS}
@@ -176,7 +176,7 @@ class PersistedDao(
   override protected val db: DBWithLogging,
   private val persistedSlick: TableQuery[PersistedSlickTable]
 ) extends H2DAO[PersistedSlickTable, PersistedSlick, DbUUID]
-  with DAOUUIDQuery[PersistedSlickTable, PersistedSlick, H2Profile]
+  with DAOUUIDQuery[PersistedSlickTable, PersistedSlick, CoolH2Profile]
   with NoopBackend
   with InSeqDbUUIDImplicits {
   override def validateCreate(

--- a/test/scala/co/actioniq/luna/DAOSpec.scala
+++ b/test/scala/co/actioniq/luna/DAOSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import co.actioniq.luna.dao.{DAOException, DbLongOptId, DbUUID, FormValidatorExceptions, FormValidatorMessageSeq}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import co.actioniq.luna.logging.{NoopBackend, TransactionAction, TransactionLogger}
 import co.actioniq.luna.example.{FilterLarry, LoggingModel, Player, PlayerDAO, PlayerTable, Team, TeamDAO, TeamTable}
 import org.junit.runner.RunWith

--- a/test/scala/co/actioniq/luna/DAOSpec.scala
+++ b/test/scala/co/actioniq/luna/DAOSpec.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{Await, Future}
 
 @RunWith(classOf[JUnitRunner])
 class DAOSpec extends Specification with Mockito {
+  /*
   "DbUUID" should {
     "handle conversions" in new TestScope with NoopLoggerProvider {
       val randomUuid = UUID.randomUUID().toString
@@ -32,6 +33,7 @@ class DAOSpec extends Specification with Mockito {
       result.head mustEqual test.binValue
     }
   }
+
 
   "MDC Data" should {
     "be maintained in DAO future" in new TestScope with NoopLoggerProvider {
@@ -53,7 +55,6 @@ class DAOSpec extends Specification with Mockito {
       MDC.get(mdcKey) mustEqual mdcVal
     }
   }
-
 
   "DbLongOptId DAO" should {
     "generate id queries" in new TestScope with NoopLoggerProvider {
@@ -98,8 +99,10 @@ class DAOSpec extends Specification with Mockito {
       ids must containTheSameElementsAs(Seq(DbLongOptId(1)))
     }
   }
+*/
 
   "DbUUID DAO" should {
+    /*
     "generate id queries" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId))
       player.get.name mustEqual "larry"
@@ -121,14 +124,17 @@ class DAOSpec extends Specification with Mockito {
       val ids = awaitResult(playerDao.createFuture(Seq(marry, zarry)))
       ids must contain(maryId, zarryId)
     }
+    */
     "updateFuture by id" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId)).get
+      println("HEERRRE")
       val updateFutureAndReadFuture = playerDao.updateAndReadFuture(player.copy(name = "Mary"))
       val newPlayer = awaitResult(updateFutureAndReadFuture)
       newPlayer.id mustEqual larryId
       newPlayer.name mustEqual "Mary"
       newPlayer.teamId mustEqual 1L
     }
+    /*
     "update two field" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId)).get
       val updateFuture = playerDao.updateFieldFuture[String, Long](
@@ -178,9 +184,10 @@ class DAOSpec extends Specification with Mockito {
       val query = playerDao.queryForIds()
       query mustEqual """select "id" from "player""""
     }
+    */
 
   }
-
+  /*
   "default filters with joins" should {
     "handle a join monad" in new TestScope with NoopLoggerProvider  {
       playerDao.queryJoinWithMonad() mustEqual
@@ -359,6 +366,7 @@ class DAOSpec extends Specification with Mockito {
     verify(tl, times(2)).write(any[LoggingModel])
     verify(tl, times(1)).flush()
   }
+  */
 
 
   trait LoggerProvider {

--- a/test/scala/co/actioniq/luna/DAOSpec.scala
+++ b/test/scala/co/actioniq/luna/DAOSpec.scala
@@ -21,7 +21,6 @@ import scala.concurrent.{Await, Future}
 
 @RunWith(classOf[JUnitRunner])
 class DAOSpec extends Specification with Mockito {
-  /*
   "DbUUID" should {
     "handle conversions" in new TestScope with NoopLoggerProvider {
       val randomUuid = UUID.randomUUID().toString
@@ -99,10 +98,8 @@ class DAOSpec extends Specification with Mockito {
       ids must containTheSameElementsAs(Seq(DbLongOptId(1)))
     }
   }
-*/
 
   "DbUUID DAO" should {
-    /*
     "generate id queries" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId))
       player.get.name mustEqual "larry"
@@ -124,7 +121,6 @@ class DAOSpec extends Specification with Mockito {
       val ids = awaitResult(playerDao.createFuture(Seq(marry, zarry)))
       ids must contain(maryId, zarryId)
     }
-    */
     "updateFuture by id" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId)).get
       println("HEERRRE")
@@ -133,6 +129,12 @@ class DAOSpec extends Specification with Mockito {
       newPlayer.id mustEqual larryId
       newPlayer.name mustEqual "Mary"
       newPlayer.teamId mustEqual 1L
+
+      val ignoreTeamUpdate = playerDao.updateAndReadFuture(newPlayer.copy(teamId = 2L))
+      val ignoreNewPlayer = awaitResult(ignoreTeamUpdate)
+      ignoreNewPlayer.id mustEqual larryId
+      ignoreNewPlayer.name mustEqual "Mary"
+      ignoreNewPlayer.teamId mustEqual 1L
     }
     /*
     "update two field" in new TestScope with NoopLoggerProvider {
@@ -165,6 +167,7 @@ class DAOSpec extends Specification with Mockito {
       )
       awaitResult(updateFuture) must throwA[FormValidatorExceptions]
     }
+    */
     "delete by id" in new TestScope with NoopLoggerProvider {
       awaitResult(playerDao.deleteFuture(larryId))
       awaitResult(playerDao.readByIdFuture(larryId)) must beNone
@@ -184,8 +187,6 @@ class DAOSpec extends Specification with Mockito {
       val query = playerDao.queryForIds()
       query mustEqual """select "id" from "player""""
     }
-    */
-
   }
   /*
   "default filters with joins" should {

--- a/test/scala/co/actioniq/luna/DAOSpec.scala
+++ b/test/scala/co/actioniq/luna/DAOSpec.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import co.actioniq.luna.dao.{DAOException, DbLongOptId, DbUUID, FormValidatorExceptions, FormValidatorMessageSeq}
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import co.actioniq.luna.logging.{NoopBackend, TransactionAction, TransactionLogger}
 import co.actioniq.luna.example.{FilterLarry, LoggingModel, Player, PlayerDAO, PlayerTable, Team, TeamDAO, TeamTable}
 import org.junit.runner.RunWith
@@ -12,7 +13,6 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import slick.jdbc.{GetResult, PositionedParameters, SetParameter}
-import slick.jdbc.H2Profile.api._
 import slick.util.SlickMDCContext.Implicits.defaultContext
 import org.slf4j.MDC
 

--- a/test/scala/co/actioniq/luna/DAOSpec.scala
+++ b/test/scala/co/actioniq/luna/DAOSpec.scala
@@ -128,11 +128,14 @@ class DAOSpec extends Specification with Mockito {
       newPlayer.id mustEqual larryId
       newPlayer.name mustEqual "Mary"
       newPlayer.teamId mustEqual 1L
+    }
 
-      val ignoreTeamUpdate = playerDao.updateAndReadFuture(newPlayer.copy(teamId = 2L))
+    "updateFuture ignore field" in new TestScope with NoopLoggerProvider {
+      val player = awaitResult(playerDao.readByIdFuture(larryId)).get
+      val ignoreTeamUpdate = playerDao.updateAndReadFuture(player.copy(teamId = 2L, name = "Harp"))
       val ignoreNewPlayer = awaitResult(ignoreTeamUpdate)
       ignoreNewPlayer.id mustEqual larryId
-      ignoreNewPlayer.name mustEqual "Mary"
+      ignoreNewPlayer.name mustEqual "Harp"
       ignoreNewPlayer.teamId mustEqual 1L
     }
 

--- a/test/scala/co/actioniq/luna/DAOSpec.scala
+++ b/test/scala/co/actioniq/luna/DAOSpec.scala
@@ -123,7 +123,6 @@ class DAOSpec extends Specification with Mockito {
     }
     "updateFuture by id" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId)).get
-      println("HEERRRE")
       val updateFutureAndReadFuture = playerDao.updateAndReadFuture(player.copy(name = "Mary"))
       val newPlayer = awaitResult(updateFutureAndReadFuture)
       newPlayer.id mustEqual larryId
@@ -136,7 +135,7 @@ class DAOSpec extends Specification with Mockito {
       ignoreNewPlayer.name mustEqual "Mary"
       ignoreNewPlayer.teamId mustEqual 1L
     }
-    /*
+
     "update two field" in new TestScope with NoopLoggerProvider {
       val player = awaitResult(playerDao.readByIdFuture(larryId)).get
       val updateFuture = playerDao.updateFieldFuture[String, Long](
@@ -167,7 +166,6 @@ class DAOSpec extends Specification with Mockito {
       )
       awaitResult(updateFuture) must throwA[FormValidatorExceptions]
     }
-    */
     "delete by id" in new TestScope with NoopLoggerProvider {
       awaitResult(playerDao.deleteFuture(larryId))
       awaitResult(playerDao.readByIdFuture(larryId)) must beNone
@@ -188,7 +186,6 @@ class DAOSpec extends Specification with Mockito {
       query mustEqual """select "id" from "player""""
     }
   }
-  /*
   "default filters with joins" should {
     "handle a join monad" in new TestScope with NoopLoggerProvider  {
       playerDao.queryJoinWithMonad() mustEqual
@@ -367,7 +364,6 @@ class DAOSpec extends Specification with Mockito {
     verify(tl, times(2)).write(any[LoggingModel])
     verify(tl, times(1)).flush()
   }
-  */
 
 
   trait LoggerProvider {

--- a/test/scala/co/actioniq/luna/DynamicTypesSpec.scala
+++ b/test/scala/co/actioniq/luna/DynamicTypesSpec.scala
@@ -1,6 +1,6 @@
 package co.actioniq.luna
 
-import co.actioniq.luna.dao.{DAO, DAODynamicProfileTable, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, IdModel, JdbcTypeImplicits, JdbcTypes}
+import co.actioniq.luna.dao.{CoolH2Profile, DAO, DAODynamicProfileTable, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, IdModel, JdbcTypeImplicits, JdbcTypes}
 import co.actioniq.luna.logging.NoopBackend
 import co.actioniq.luna.OptionCompareOption.optionCompare
 import org.junit.runner.RunWith
@@ -27,7 +27,7 @@ class DynamicTypesSpec extends Specification with Mockito {
     implicit val logger = new NoopBackend {}
     val dao = new PersistedDao(
       db,
-      H2Profile,
+      CoolH2Profile,
       dynamicSlick
     ) with JdbcTypeImplicits.h2JdbcTypeImplicits.DbImplicits
   }
@@ -73,10 +73,10 @@ class DynamicTypesSpec extends Specification with Mockito {
   object DynamicSlick {
     trait H2Provider {
       private val creator = (tag: Tag) => {
-        val wrapper = new DynamicWrapper(H2Profile, JdbcTypeImplicits.h2JdbcTypeImplicits)
+        val wrapper = new DynamicWrapper(CoolH2Profile, JdbcTypeImplicits.h2JdbcTypeImplicits)
           new wrapper.DynamicSlickTable(tag)
       }
-      val dynamicSlick = new TableQuery[DynamicWrapper[H2Profile]#DynamicSlickTable](creator)
+      val dynamicSlick = new TableQuery[DynamicWrapper[CoolH2Profile]#DynamicSlickTable](creator)
     }
     trait MysqlProvider {
       private val creator = (tag: Tag) => {

--- a/test/scala/co/actioniq/luna/DynamicTypesSpec.scala
+++ b/test/scala/co/actioniq/luna/DynamicTypesSpec.scala
@@ -1,6 +1,6 @@
 package co.actioniq.luna
 
-import co.actioniq.luna.dao.{CoolH2Profile, DAO, DAODynamicProfileTable, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, IdModel, JdbcTypeImplicits, JdbcTypes}
+import co.actioniq.luna.dao.{DAOH2Profile, DAO, DAODynamicProfileTable, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, IdModel, JdbcTypeImplicits, JdbcTypes}
 import co.actioniq.luna.logging.NoopBackend
 import co.actioniq.luna.OptionCompareOption.optionCompare
 import org.junit.runner.RunWith
@@ -27,7 +27,7 @@ class DynamicTypesSpec extends Specification with Mockito {
     implicit val logger = new NoopBackend {}
     val dao = new PersistedDao(
       db,
-      CoolH2Profile,
+      DAOH2Profile,
       dynamicSlick
     ) with JdbcTypeImplicits.h2JdbcTypeImplicits.DbImplicits
   }
@@ -73,10 +73,10 @@ class DynamicTypesSpec extends Specification with Mockito {
   object DynamicSlick {
     trait H2Provider {
       private val creator = (tag: Tag) => {
-        val wrapper = new DynamicWrapper(CoolH2Profile, JdbcTypeImplicits.h2JdbcTypeImplicits)
+        val wrapper = new DynamicWrapper(DAOH2Profile, JdbcTypeImplicits.h2JdbcTypeImplicits)
           new wrapper.DynamicSlickTable(tag)
       }
-      val dynamicSlick = new TableQuery[DynamicWrapper[CoolH2Profile]#DynamicSlickTable](creator)
+      val dynamicSlick = new TableQuery[DynamicWrapper[DAOH2Profile]#DynamicSlickTable](creator)
     }
     trait MysqlProvider {
       private val creator = (tag: Tag) => {

--- a/test/scala/co/actioniq/luna/SoftDeleteSpec.scala
+++ b/test/scala/co/actioniq/luna/SoftDeleteSpec.scala
@@ -3,13 +3,13 @@ package co.actioniq.luna
 import java.util.concurrent.TimeUnit
 
 import co.actioniq.luna.dao.DbUUID
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import co.actioniq.luna.example.{Kitty, KittyDAO}
 import co.actioniq.luna.logging.NoopBackend
 import org.junit.runner.RunWith
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}

--- a/test/scala/co/actioniq/luna/SoftDeleteSpec.scala
+++ b/test/scala/co/actioniq/luna/SoftDeleteSpec.scala
@@ -3,7 +3,7 @@ package co.actioniq.luna
 import java.util.concurrent.TimeUnit
 
 import co.actioniq.luna.dao.DbUUID
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import co.actioniq.luna.example.{Kitty, KittyDAO}
 import co.actioniq.luna.logging.NoopBackend
 import org.junit.runner.RunWith

--- a/test/scala/co/actioniq/luna/example/FilterLarry.scala
+++ b/test/scala/co/actioniq/luna/example/FilterLarry.scala
@@ -1,11 +1,11 @@
 package co.actioniq.luna.example
 
-import co.actioniq.luna.dao.{DefaultFilter, H2DAOTable, IdModel, IdType}
+import co.actioniq.luna.dao.{CoolH2Profile, DefaultFilter, H2DAOTable, IdModel, IdType}
 import slick.jdbc.{H2Profile, JdbcProfile}
 
 trait FilterLarry[T <: H2DAOTable[V, I]
   with NameTable, V <: IdModel[I], I <: IdType]
-  extends DefaultFilter[T, V, I, H2Profile] {
+  extends DefaultFilter[T, V, I, CoolH2Profile] {
   protected val profile: JdbcProfile
   protected val name: String = "larry"
   import profile.api._ // scalastyle:ignore

--- a/test/scala/co/actioniq/luna/example/FilterLarry.scala
+++ b/test/scala/co/actioniq/luna/example/FilterLarry.scala
@@ -1,11 +1,11 @@
 package co.actioniq.luna.example
 
-import co.actioniq.luna.dao.{CoolH2Profile, DefaultFilter, H2DAOTable, IdModel, IdType}
+import co.actioniq.luna.dao.{DAOH2Profile, DefaultFilter, H2DAOTable, IdModel, IdType}
 import slick.jdbc.{H2Profile, JdbcProfile}
 
 trait FilterLarry[T <: H2DAOTable[V, I]
   with NameTable, V <: IdModel[I], I <: IdType]
-  extends DefaultFilter[T, V, I, CoolH2Profile] {
+  extends DefaultFilter[T, V, I, DAOH2Profile] {
   protected val profile: JdbcProfile
   protected val name: String = "larry"
   import profile.api._ // scalastyle:ignore

--- a/test/scala/co/actioniq/luna/example/Kitty.scala
+++ b/test/scala/co/actioniq/luna/example/Kitty.scala
@@ -1,7 +1,7 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.dao.{DbUUID, H2DAOTable, H2IdModel}
-import slick.jdbc.H2Profile.api._
+import co.actioniq.luna.dao.CoolH2Profile.api._
 
 case class Kitty(
   override val id: DbUUID,

--- a/test/scala/co/actioniq/luna/example/Kitty.scala
+++ b/test/scala/co/actioniq/luna/example/Kitty.scala
@@ -1,7 +1,7 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.dao.{DbUUID, H2DAOTable, H2IdModel}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.DAOH2Profile.api._
 
 case class Kitty(
   override val id: DbUUID,

--- a/test/scala/co/actioniq/luna/example/KittyDAO.scala
+++ b/test/scala/co/actioniq/luna/example/KittyDAO.scala
@@ -2,12 +2,12 @@ package co.actioniq.luna.example
 
 import co.actioniq.luna.DBWithLogging
 import co.actioniq.luna.dao._
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import co.actioniq.luna.logging.NoopBackend
 import slick.dbio.Effect
 import slick.jdbc.{H2Profile, JdbcType}
 import slick.lifted.TableQuery
 import slick.util.SlickMDCContext
-import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext
 
@@ -16,8 +16,8 @@ class KittyDAO(
   override val slickQuery: TableQuery[KittyTable]
 ) extends H2DAO[KittyTable, Kitty, DbUUID]
   with NoopBackend
-  with DAOUUIDQuery[KittyTable, Kitty, H2Profile]
-  with SoftDeleteOptional[KittyTable, Kitty, DbUUID, H2Profile, Long]{
+  with DAOUUIDQuery[KittyTable, Kitty, CoolH2Profile]
+  with SoftDeleteOptional[KittyTable, Kitty, DbUUID, CoolH2Profile, Long]{
 
   override protected implicit val ec: ExecutionContext = SlickMDCContext.Implicits.defaultContext
 

--- a/test/scala/co/actioniq/luna/example/KittyDAO.scala
+++ b/test/scala/co/actioniq/luna/example/KittyDAO.scala
@@ -2,7 +2,7 @@ package co.actioniq.luna.example
 
 import co.actioniq.luna.DBWithLogging
 import co.actioniq.luna.dao._
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import co.actioniq.luna.logging.NoopBackend
 import slick.dbio.Effect
 import slick.jdbc.{H2Profile, JdbcType}
@@ -16,8 +16,8 @@ class KittyDAO(
   override val slickQuery: TableQuery[KittyTable]
 ) extends H2DAO[KittyTable, Kitty, DbUUID]
   with NoopBackend
-  with DAOUUIDQuery[KittyTable, Kitty, CoolH2Profile]
-  with SoftDeleteOptional[KittyTable, Kitty, DbUUID, CoolH2Profile, Long]{
+  with DAOUUIDQuery[KittyTable, Kitty, DAOH2Profile]
+  with SoftDeleteOptional[KittyTable, Kitty, DbUUID, DAOH2Profile, Long]{
 
   override protected implicit val ec: ExecutionContext = SlickMDCContext.Implicits.defaultContext
 

--- a/test/scala/co/actioniq/luna/example/Player.scala
+++ b/test/scala/co/actioniq/luna/example/Player.scala
@@ -1,6 +1,6 @@
 package co.actioniq.luna.example
 
-import co.actioniq.luna.dao.{DbUUID, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
+import co.actioniq.luna.dao.{CoolColumnOption, DbUUID, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
 import co.actioniq.luna.dao.CoolH2Profile.api._
 import slick.lifted.{Rep, Tag}
 
@@ -14,7 +14,7 @@ class PlayerTable(tag: Tag)
   extends H2DAOTable[Player, DbUUID](tag, "player") with NameTable {
 
   override def id: Rep[DbUUID] = column[DbUUID]("id")
-  def teamId: Rep[Long] = column[Long]("team_id")
+  def teamId: Rep[Long] = column[Long]("team_id", CoolColumnOption.IgnoreUpdate)
   override def name: Rep[String] = column[String]("name")
 
   override def * = ( // scalastyle:ignore

--- a/test/scala/co/actioniq/luna/example/Player.scala
+++ b/test/scala/co/actioniq/luna/example/Player.scala
@@ -1,7 +1,7 @@
 package co.actioniq.luna.example
 
-import co.actioniq.luna.dao.{CoolColumnOption, DbUUID, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.{ExtraColumnOption, DbUUID, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import slick.lifted.{Rep, Tag}
 
 case class Player(
@@ -17,8 +17,8 @@ case class LiftedPlayerUpdate(
 class PlayerTable(tag: Tag)
   extends H2DAOTable[Player, DbUUID](tag, "player") with NameTable {
 
-  override def id: Rep[DbUUID] = column[DbUUID]("id", CoolColumnOption.IgnoreUpdate)
-  def teamId: Rep[Long] = column[Long]("team_id", CoolColumnOption.IgnoreUpdate)
+  override def id: Rep[DbUUID] = column[DbUUID]("id", ExtraColumnOption.IgnoreUpdate)
+  def teamId: Rep[Long] = column[Long]("team_id", ExtraColumnOption.IgnoreUpdate)
   override def name: Rep[String] = column[String]("name")
 
   override def * = ( // scalastyle:ignore

--- a/test/scala/co/actioniq/luna/example/Player.scala
+++ b/test/scala/co/actioniq/luna/example/Player.scala
@@ -1,7 +1,7 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.dao.{DbUUID, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
-import slick.jdbc.H2Profile.api._
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import slick.lifted.{Rep, Tag}
 
 case class Player(

--- a/test/scala/co/actioniq/luna/example/Player.scala
+++ b/test/scala/co/actioniq/luna/example/Player.scala
@@ -10,6 +10,10 @@ case class Player(
   name: String
 ) extends H2IdModel[DbUUID]
 
+case class LiftedPlayerUpdate(
+  name: Rep[String]
+)
+
 class PlayerTable(tag: Tag)
   extends H2DAOTable[Player, DbUUID](tag, "player") with NameTable {
 

--- a/test/scala/co/actioniq/luna/example/Player.scala
+++ b/test/scala/co/actioniq/luna/example/Player.scala
@@ -17,7 +17,7 @@ case class LiftedPlayerUpdate(
 class PlayerTable(tag: Tag)
   extends H2DAOTable[Player, DbUUID](tag, "player") with NameTable {
 
-  override def id: Rep[DbUUID] = column[DbUUID]("id")
+  override def id: Rep[DbUUID] = column[DbUUID]("id", CoolColumnOption.IgnoreUpdate)
   def teamId: Rep[Long] = column[Long]("team_id", CoolColumnOption.IgnoreUpdate)
   override def name: Rep[String] = column[String]("name")
 

--- a/test/scala/co/actioniq/luna/example/PlayerDAO.scala
+++ b/test/scala/co/actioniq/luna/example/PlayerDAO.scala
@@ -1,11 +1,10 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.DBWithLogging
-import co.actioniq.luna.dao.{DAOUUIDQuery, DbLongOptId, DbUUID, FormValidatorMessageSeq, H2DAO}
+import co.actioniq.luna.dao.{CoolH2Profile, DAOUUIDQuery, DbLongOptId, DbUUID, FormValidatorMessageSeq, H2DAO}
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import co.actioniq.luna.logging.TransactionAction
 import slick.dbio.DBIOAction
-import slick.jdbc.H2Profile
-import slick.jdbc.H2Profile.api._
 import slick.lifted.{Rep, TableQuery}
 import slick.util.SlickMDCContext
 
@@ -17,7 +16,7 @@ class PlayerDAO(
   override val slickQuery: TableQuery[PlayerTable],
   val teamDao: TeamDAO
 ) extends H2DAO[PlayerTable, Player, DbUUID]
-  with DAOUUIDQuery[PlayerTable, Player, H2Profile] {
+  with DAOUUIDQuery[PlayerTable, Player, CoolH2Profile] {
 
   override protected implicit val ec: ExecutionContext = SlickMDCContext.Implicits.defaultContext
 

--- a/test/scala/co/actioniq/luna/example/PlayerDAO.scala
+++ b/test/scala/co/actioniq/luna/example/PlayerDAO.scala
@@ -1,8 +1,8 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.DBWithLogging
-import co.actioniq.luna.dao.{CoolH2Profile, DAOUUIDQuery, DbLongOptId, DbUUID, FormValidatorMessageSeq, H2DAO}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.{DAOH2Profile, DAOUUIDQuery, DbLongOptId, DbUUID, FormValidatorMessageSeq, H2DAO}
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import co.actioniq.luna.logging.TransactionAction
 import slick.dbio.DBIOAction
 import slick.lifted.{Rep, TableQuery}
@@ -16,7 +16,7 @@ class PlayerDAO(
   override val slickQuery: TableQuery[PlayerTable],
   val teamDao: TeamDAO
 ) extends H2DAO[PlayerTable, Player, DbUUID]
-  with DAOUUIDQuery[PlayerTable, Player, CoolH2Profile] {
+  with DAOUUIDQuery[PlayerTable, Player, DAOH2Profile] {
 
   override protected implicit val ec: ExecutionContext = SlickMDCContext.Implicits.defaultContext
 

--- a/test/scala/co/actioniq/luna/example/Team.scala
+++ b/test/scala/co/actioniq/luna/example/Team.scala
@@ -1,7 +1,7 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.dao.{DbLongOptId, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
-import slick.jdbc.H2Profile.api._
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import slick.lifted.{Rep, TableQuery, Tag}
 
 case class Team(

--- a/test/scala/co/actioniq/luna/example/Team.scala
+++ b/test/scala/co/actioniq/luna/example/Team.scala
@@ -1,7 +1,7 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.dao.{DbLongOptId, H2DAOTable, H2IdModel, IdModel, JdbcTypeImplicits}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import slick.lifted.{Rep, TableQuery, Tag}
 
 case class Team(

--- a/test/scala/co/actioniq/luna/example/TeamDAO.scala
+++ b/test/scala/co/actioniq/luna/example/TeamDAO.scala
@@ -1,8 +1,8 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.DBWithLogging
-import co.actioniq.luna.dao.{CoolH2Profile, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO}
-import co.actioniq.luna.dao.CoolH2Profile.api._
+import co.actioniq.luna.dao.{DAOH2Profile, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO}
+import co.actioniq.luna.dao.DAOH2Profile.api._
 import co.actioniq.luna.logging.NoopBackend
 import slick.dbio.DBIOAction
 import slick.lifted.TableQuery
@@ -15,7 +15,7 @@ class TeamDAO(
   override val slickQuery: TableQuery[TeamTable]
 ) extends H2DAO[TeamTable, Team, DbLongOptId]
   with NoopBackend
-  with DAOLongIdQuery[TeamTable, Team, CoolH2Profile] {
+  with DAOLongIdQuery[TeamTable, Team, DAOH2Profile] {
 
   def readByIdQueryStatement(id: DbLongOptId): String = readByIdQuery(id).result.statements.head
 

--- a/test/scala/co/actioniq/luna/example/TeamDAO.scala
+++ b/test/scala/co/actioniq/luna/example/TeamDAO.scala
@@ -1,11 +1,10 @@
 package co.actioniq.luna.example
 
 import co.actioniq.luna.DBWithLogging
-import co.actioniq.luna.dao.{DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO}
+import co.actioniq.luna.dao.{CoolH2Profile, DAOLongIdQuery, DbLongOptId, FormValidatorMessageSeq, H2DAO}
+import co.actioniq.luna.dao.CoolH2Profile.api._
 import co.actioniq.luna.logging.NoopBackend
 import slick.dbio.DBIOAction
-import slick.jdbc.H2Profile
-import slick.jdbc.H2Profile.api._
 import slick.lifted.TableQuery
 import slick.util.SlickMDCContext
 
@@ -16,7 +15,7 @@ class TeamDAO(
   override val slickQuery: TableQuery[TeamTable]
 ) extends H2DAO[TeamTable, Team, DbLongOptId]
   with NoopBackend
-  with DAOLongIdQuery[TeamTable, Team, H2Profile] {
+  with DAOLongIdQuery[TeamTable, Team, CoolH2Profile] {
 
   def readByIdQueryStatement(id: DbLongOptId): String = readByIdQuery(id).result.statements.head
 


### PR DESCRIPTION
Often we will just use the update function with a case class.  The goal is to NOT update fields that
are keys (like an id) because these shouldn't change and can cause deadlocks.  I added a compile step
that will remove fields from update statements that are annotated to not update.  Created wrapper profiles for mysql and h2 that include the compile step.